### PR TITLE
fix `get_log_files` for services with 0 log files

### DIFF
--- a/src/smf.rs
+++ b/src/smf.rs
@@ -476,6 +476,7 @@ impl Query {
         Ok(self
             .run(args)?
             .split('\n')
+            .filter(|l| !l.is_empty())
             .map(|s| s.parse::<PathBuf>())
             .collect::<Result<Vec<PathBuf>, _>>()
             .unwrap()


### PR DESCRIPTION
I noticed this when testing with a service that didn't have any log files.  For example:

```
$ svcs -L svc:/network/ipfilter:default
$
```

Using this test program:

``` rust
fn main() {
    let fmri = "svc:/network/ipfilter:default";
    let log_files: Vec<_> =
        smf::Query::new().get_log_files(&[fmri]).unwrap().collect();

    println!("length = {}", log_files.len());
    println!("{:#?}", log_files);
}
```

It yields (before my change):

```
$ cargo run -q
length = 1
[
    "",
]
```

after my change:

```
$ cargo run -q
length = 0
[]
```