### PR TITLE
fix for when a service has 0 dependents or dependencies

### DIFF
--- a/src/smf.rs
+++ b/src/smf.rs
@@ -326,6 +326,7 @@ impl Query {
         Ok(self
             .run(args)?
             .split('\n')
+            .filter(|l| !l.is_empty())
             .map(|s| s.parse::<SvcStatus>())
             .collect::<Result<Vec<SvcStatus>, _>>()?
             .into_iter())


### PR DESCRIPTION
very similar to https://github.com/oxidecomputer/smf/pull/6

using this test program on a service i have with 0 dependents:

``` rust
fn main() {
    let fmri = "svc:/ooce/application/nrpe:default";
    let dependents: Vec<_> =
        smf::Query::new().get_dependents_of(&[fmri]).unwrap().collect();

    println!("found {} dependents", dependents.len());
}
```

before this change

```
$ cargo run -q
thread 'main' panicked at src/main.rs:4:54:
called `Result::unwrap()` on an `Err` value: Parse("Missing FMRI")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after this change

```
$ cargo run -q
found 0 dependents
```